### PR TITLE
loosen up nokogiri version requirement

### DIFF
--- a/rubywbem.gemspec
+++ b/rubywbem.gemspec
@@ -46,5 +46,5 @@ direct port of pyWbem (http://pywbem.sourceforge.net).}
   gem.require_paths = ["lib"]
   gem.version       = WBEM::VERSION
 
-  gem.add_dependency('nokogiri', '~>1.5.0')
+  gem.add_dependency('nokogiri', '~>1.5')
 end


### PR DESCRIPTION
Rails 4 depends on nokogiri 1.6, so we need to loosen this requirement
so that it will work with Rails.
